### PR TITLE
update to transform-pouch@1.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var transform = require('transform-pouch').transform;
 var uuid = require('node-uuid');
 function genKey(password, salt) {
   return new PouchPromise(function (resolve, reject) {
-    pbkdf2(password, salt, 1000, 256 / 8, function (err, key) {
+    pbkdf2.pbkdf2(password, salt, 1000, 256 / 8, function (err, key) {
       password = null;
       if (err) {
         return reject(err);
@@ -58,12 +58,12 @@ function cryptoInit(password) {
   });
   db.transform({
     incoming: function (doc) {
-      return pending.then(function (doc) {
+      return pending.then(function () {
         return encrypt(doc);
       });
     },
     outgoing: function (doc) {
-      return pending.then(function (doc) {
+      return pending.then(function () {
         return decrypt(doc);
       });
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pbkdf2": "^3.0.4",
     "pouchdb-promise": "0.0.0",
     "randombytes": "^2.0.3",
-    "transform-pouch": "^1.0.2"
+    "transform-pouch": "^1.1.0"
   },
   "devDependencies": {
     "browserify": "^6.3.3",


### PR DESCRIPTION
makes https://github.com/calvinmetcalf/crypto-pouch/pull/26 mergable

- updated to latest transform-pouch
- fixed a little issue in the `pending` promise handlers
- fixed usage of `pbkdf2`