### PR TITLE
put with _deleted: true

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function cryptoInit(password, options) {
   var db = this;
   var key, pub;
   var turnedOff = false;
-  var ignore = ['_id', '_rev']
+  var ignore = ['_id', '_rev', '_deleted']
 
   if (!options) {
     options = {};

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ If the second argument is an object:
 
 - `options.ignore`  
   String or Array of Strings of properties that will not be encrypted.  
+- `options.digest`  
+  Any of `sha1`, `sha256`, `sha512` (default).
 
 
 ### db.removeCrypto()

--- a/test.js
+++ b/test.js
@@ -145,3 +145,21 @@ test('options.digest with sha512 default', function (t) {
     t.ok(err, 'throws error for different write / read digest');;
   });
 });
+test('put with _deleted: true', function (t) {
+  t.plan(1);
+  var dbName = 'twelve';
+  var db = new PouchDB(dbName, {db: memdown});
+  db.crypto('password')
+  var doc = {_id: 'baz', foo: 'bar'}
+  db.put(doc).then(function (result) {
+    doc._rev = result.rev
+    doc._deleted = true
+    return db.put(doc)
+  }).then(function () {
+    return db.get('baz')
+  }).then(function () {
+    t.error('should not find doc after delete');
+  }).catch(function (err) {
+    t.equal(err.status, 404, 'cannot find doc after delete')
+  })
+})


### PR DESCRIPTION
This is rebased on #33

With the current implementation, the `_deleted` property gets encrypted with the other properties, so that a `db.put(deletedDoc)` will not remove the doc, but create a new revision without the `_deleted` true property. See https://travis-ci.org/calvinmetcalf/crypto-pouch/builds/128413187 for failing test