### PR TITLE
Add the possibility to temporarily disable encryption and to re-use `.crypto()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,11 +64,11 @@ Disables encryption on the database and forgets your password.
 
 ### db.disableCrypto()
 
-Disable encryption on the database but keep the password if we only want to temporarily disable it. It can be enabled back later with `.enableCrypto()`.
+Disables encryption on the database but keeps the password if we only want to temporarily disable it. It can be enabled back later with `.enableCrypto()`.
 
 ### db.enableCrypto()
 
-Enable the encryption back.
+Enables the encryption back.
 
 ## Details
 

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,14 @@ db.crypto({ password, ignore: [...] }).then(() => {
 
 Disables encryption on the database and forgets your password.
 
+### db.disableCrypto()
+
+Disable encryption on the database but keep the password if we only want to temporarily disable it. It can be enabled back later with `.enableCrypto()`.
+
+### db.enableCrypto()
+
+Enable the encryption back.
+
 ## Details
 
 If you replicate to another database, Crypto-Pouch will decrypt documents before


### PR DESCRIPTION
Hey there,

thank you for this plugin that is really helpfull for my project. However I had to do a few changes to make it work as I needed.  It's the first time I use the pull-request feature so excuse me if I didn't do the stuff properly 🙏 

I noticed that I couldn't use `db.crypto(...)` twice after using `db.removeCrypto()` because the `transform-pouch` was still set after removing `_crypt` so I had an encoding problem on the 2nd run. The work around I did check if the crypto was set up once so it won't add again the transform stuff. 

Also, we can remove encryption on the database and forgets the password but we couldn't temporarily disable the encryption and re-enable it back in the same `db.crypto(...)`, so I just added it.

I'm creating this pull-request just in case someone need this stuff, the tests ran properly. If you don't need it, feel free to refuse it. Cheers